### PR TITLE
Validate the support service requests

### DIFF
--- a/breez/breez.proto
+++ b/breez/breez.proto
@@ -459,14 +459,12 @@ message GetReverseRoutingNodeReply {
 message ReportPaymentFailureRequest {
   // The node pubkey reporting the failure
   string node_id = 1;
-  // The hash of the API key
-  string api_key_hash = 2;
   // The ISO 8601 timestamp 
-  string timestamp = 3;
+  string timestamp = 2;
   // The optional comment/error response text
-  string comment = 4;
+  string comment = 3;
   // The JSON encoded report payload
-  string report = 5;
+  string report = 4;
 }
 message ReportPaymentFailureReply {}
 

--- a/email.go
+++ b/email.go
@@ -156,7 +156,6 @@ func sendPaymentFailureNotification(in *breez.ReportPaymentFailureRequest) error
 
 	tpl := `
 	<div>NodeId: {{ .node_id }}</div>
-	<div>APIKeyHash: {{ .api_key_hash }}</div>
 	<div>Timestamp: {{ .timestamp }}</div>
 	<div>Comment/error: {{ .comment }}</div>
 	<div>Report:</div>

--- a/server.go
+++ b/server.go
@@ -540,7 +540,7 @@ func main() {
 		),
 	)
 
-	supportServer := support.NewServer(sendPaymentFailureNotification, breezStatus)
+	supportServer := support.NewServer(sendPaymentFailureNotification, breezStatus, lspList)
 	breez.RegisterSupportServer(s, supportServer)
 
 	swapperServer = swapper.NewServer(network, redisPool, client, ssClient, subswapClient, ssWalletKitClient, ssRouterClient,


### PR DESCRIPTION
This PR adds validation to the support service requests. It gets the API key token from the authentication header and queries for lsps, failing if no lsps are associated to the API key.

I have removed the api_key_hash message field, @yaslama please can you rerun the protoc generation